### PR TITLE
Use setuptools version logic for py version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ import sys
 import setuptools
 
 PACKAGE_NAME = "cqkit"
-MINIMUM_PYTHON_VERSION = "3.6"
 
 loc = os.path.abspath(os.path.dirname(__file__))
 
@@ -36,12 +35,6 @@ for line in requirements:
         required.append(line)
 
 
-def check_python_version():
-    """Exit when the Python version is too low."""
-    if sys.version < MINIMUM_PYTHON_VERSION:
-        sys.exit("Python {0}+ is required.".format(MINIMUM_PYTHON_VERSION))
-
-
 def read_package_variable(key, filename="__init__.py"):
     """Read the value of a variable from the package without importing."""
     module_path = os.path.join(PACKAGE_NAME, filename)
@@ -64,8 +57,6 @@ def build_description():
         return readme + "\n" + changelog
 
 
-check_python_version()
-
 setuptools.setup(
     name=read_package_variable("__project__"),
     version=read_package_variable("__version__"),
@@ -73,6 +64,7 @@ setuptools.setup(
     url="https://github.com/michaelgale/cq-kit",
     author="Michael Gale",
     author_email="michael@fxbricks.com",
+    python_requires='>=3.6',
     packages=setuptools.find_packages(),
     long_description=build_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
The old logic breaks with python versions >= 3.9, as version "3.10" is less than "3.6" via string comparison but semantically fulfils the requirements. Since python 3.6 should be newer than the pip and setuptools required for this feature (setuptools>=24.2.0/pip>=9.0.0) there should be no regression in version support.